### PR TITLE
fix: minor fixes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,6 +29,5 @@ module.exports = {
         },
       },
     },
-    'gatsby-plugin-root-import',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint-plugin-react": "^7.16.0",
     "favicons": "^5.4.1",
     "gatsby-plugin-eslint": "^2.0.5",
-    "gatsby-plugin-root-import": "^2.0.5",
     "husky": "^3.0.8",
     "lighthouse": "^5.5.0",
     "mkdirp": "^0.5.1",

--- a/src/components/head/head.js
+++ b/src/components/head/head.js
@@ -45,7 +45,6 @@ const Head = ({
 
     <meta content="website" property="og:type" />
     <meta content={siteTitle} property="og:site_name" />
-    <meta content={social.fbAppId} property="fb:app_id" />
     <meta content="summary_large_image" name="twitter:card" />
     <meta content={`@${social.twitter}`} name="twitter:site" />
     <meta content={`@${social.twitter}`} name="twitter:creator" />
@@ -192,7 +191,6 @@ const HeadWithQuery = props => (
             themeColor
             social {
               twitter
-              fbAppId
             }
           }
         }

--- a/src/components/io-example/io-example.css.js
+++ b/src/components/io-example/io-example.css.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { accent } from 'constants/theme';
 
 export const Container = styled.div`
   padding: 4rem;
@@ -10,5 +9,5 @@ export const Container = styled.div`
   color: #fff;
   transition: background-color 0.3s ease;
 
-  background-color: ${({ isVisible }) => (isVisible ? accent : ' #333')};
+  background-color: ${({ isVisible }) => (isVisible ? ' #f00' : ' #333')};
 `;


### PR DESCRIPTION
- Remove gatsby-plugin-root-import; apparently it's not needed because
  the starter comes with absolute imports anyways.
- Remove all references to FB app ID
- Remove references to `{ accent }` import (for some reason linter
  doesn't catch this??)