### PR TITLE
feat(Components): Add button and card

### DIFF
--- a/src/components/button/button.css.js
+++ b/src/components/button/button.css.js
@@ -1,0 +1,61 @@
+import styled, { css } from 'styled-components';
+
+import { theme } from 'constants/theme';
+
+const makePalette = ({
+  bgColor,
+  bgColorActive,
+  bgColorHover,
+  bgColorDisabled,
+  textColor,
+}) => css`
+  background-color: ${bgColor};
+  color: ${textColor};
+  :hover {
+    background-color: ${bgColorHover};
+  }
+  :active {
+    background-color: ${bgColorActive};
+  }
+  :disabled {
+    background-color: ${bgColorDisabled};
+  }
+`;
+
+const PALETTES = {
+  primary: makePalette({
+    bgColor: theme.colors.Oranges[60],
+    bgColorHover: theme.colors.Oranges[30],
+    bgColorActive: theme.colors.Oranges[60],
+    bgColorDisabled: theme.colors.Grays[60],
+    textColor: theme.colors.Whites[100],
+  }),
+  secondary: makePalette({
+    bgColor: theme.colors.Blues[100],
+    bgColorHover: theme.colors.Blues[60],
+    bgColorActive: theme.colors.Blues[100],
+    bgColorDisabled: theme.colors.Grays[60],
+    textColor: theme.colors.Whites[100],
+  }),
+  tertiary: makePalette({
+    bgColor: theme.colors.Whites[100],
+    bgColorHover: theme.colors.Grays[8],
+    bgColorActive: theme.colors.Grays[30],
+    bgColorDisabled: theme.colors.Grays[30],
+    textColor: theme.colors.Blues[100],
+  }),
+};
+
+export const Container = styled.button`
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  font-weight: 600;
+  padding: 1rem 2rem;
+
+  :disabled {
+    cursor: default;
+  }
+
+  ${p => PALETTES[p.palette]}
+`;

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as Styled from './button.css';
+
+/**
+ * A static display component that provides padding and a slight shadow.
+ */
+const Button = ({ children, disabled, palette }) => (
+  <Styled.Container disabled={disabled} palette={palette}>
+    {children}
+  </Styled.Container>
+);
+
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  disabled: PropTypes.boolean,
+  palette: PropTypes.oneOf(['primary', 'secondary', 'tertiary']),
+};
+
+export default Button;

--- a/src/components/card/card.css.js
+++ b/src/components/card/card.css.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  padding: 1.25rem 1.5rem 1.5rem 0.75rem;
+  box-shadow: 0px 3px 7px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+`;

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as Styled from './card.css';
+
+/**
+ * A static display component that provides padding and a slight shadow.
+ */
+const Card = ({ children }) => <Styled.Container>{children}</Styled.Container>;
+
+Card.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Card;

--- a/src/constants/theme/colors.js
+++ b/src/constants/theme/colors.js
@@ -1,4 +1,4 @@
-export const White = {
+export const Whites = {
   100: '#FFFFFF',
 };
 
@@ -23,6 +23,7 @@ export const Oranges = {
 
 export const Blues = {
   100: '#386688',
+  60: '#6B99BB',
   30: '#EBEFF3',
 };
 

--- a/src/constants/theme/typography.js
+++ b/src/constants/theme/typography.js
@@ -1,30 +1,32 @@
 export const h1 = {
   fontSize: '72px',
-  fontWeight: '700',
+  fontWeight: 700,
   letterSpacing: '-0.035em',
 };
 export const h2 = {
   fontSize: '60px',
-  fontWeight: '700',
+  fontWeight: 700,
   letterSpacing: '-0.035em',
 };
 export const h3 = {
   fontSize: '48px',
-  fontWeight: '700',
+  fontWeight: 700,
   letterSpacing: '-0.035em',
 };
 export const h4 = {
   fontSize: '36px',
-  fontWeight: '700',
+  fontWeight: 700,
   letterSpacing: '-0.035em',
 };
 export const h5 = {
   fontSize: '30px',
-  fontWeight: '600',
-  letterSpacing: '0',
+  fontWeight: 600,
 };
 export const h6 = {
   fontSize: '24px',
-  fontWeight: '600',
-  letterSpacing: '0',
+  fontWeight: 600,
+};
+export const p = {
+  fontSize: '20px',
+  fontWeight: 500,
 };


### PR DESCRIPTION
Adds core components.

Colors for buttons are generally placeholders and can be optimized.

<img width="727" alt="Screen Shot 2019-10-12 at 5 14 48 PM" src="https://user-images.githubusercontent.com/5831434/66707756-e691ff00-ed13-11e9-8156-9803b5eb9562.png">
