### PR TITLE
fix: fix Lighthouse tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,15 @@ jobs:
           # Fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
 
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      # Run tests
-      - run: yarn test
+      # Run tests (lighthouse only for now as we have no unit tests)
+      - run: yarn test:lighthouse
       - run: yarn build
       # - deploy:
       #     command: |

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
   },
   "rules": {
     "strict": 0,
-    "no-console": "error",
+    "no-console": ["error", { allow: ["info", "warn", "error"] }],
     "quotes": [
       "warn",
       "single"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build:favicons": "node scripts/favicons",
     "build": "npm run build:dir && npm run build:favicons && gatsby build",
     "lint": "eslint src/**/*.js --fix",
-    "test": "ava **/*.test.js --verbose",
+    "test:unit": "ava **/*.test.js --verbose",
+    "test:lighthouse": "ava scripts/lighthouse.js --verbose",
+    "test": "yarn test:unit && yarn test:lighthouse",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
- Fix AVA API call in lighthouse test
- Point lighthouse test at our actual Gatsby site (for now)
- Minor: use `frozen-lockfile` flag in CI to avoid unexpected version
  changes
- Minor: Allow for non `console.log` `console` statements