### PR TITLE
feat: add recaptcha for Slack invites

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-google-recaptcha-v3": "^1.5.0",
     "react-headroom": "^3.0.0",
     "react-helmet": "^5.2.0",
     "react-pose": "^4.0.5",

--- a/src/components/shared/inviteform/inviteform.css.js
+++ b/src/components/shared/inviteform/inviteform.css.js
@@ -19,8 +19,3 @@ export const Input = styled.input`
   }
 `;
 
-export const Message = styled.p`
-  color: ${p => p.theme.colors.Grays[100]};
-  font-size: 16px;
-  font-weight: 600;
-`;

--- a/src/components/shared/inviteform/inviteform.js
+++ b/src/components/shared/inviteform/inviteform.js
@@ -1,8 +1,10 @@
 import React, { useState, useCallback } from 'react';
 import axios from 'axios';
+import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 
 import * as Styled from './inviteform.css';
-import Button from '../button';
+import Button from 'components/shared/button';
+import Text from 'components/shared/text';
 
 const EMAIL_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 const isValidEmail = email => EMAIL_REGEX.test(email.toLowerCase());
@@ -13,46 +15,80 @@ const isValidEmail = email => EMAIL_REGEX.test(email.toLowerCase());
 const InviteForm = () => {
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState({});
+  const { executeRecaptcha } = useGoogleReCaptcha();
   const handleEmailChange = e => {
-    setMessage('');
+    setMessage({});
     setEmail(e.target.value);
   };
+
   const handleSubmit = useCallback(async e => {
     e.preventDefault();
 
+    if (!isValidEmail(email)) {
+      return setMessage({
+        error: true,
+        body: 'Please enter a valid email address.',
+      });
+    }
+
     try {
       setLoading(true);
+
+      const recaptchaToken = await executeRecaptcha('slack_invite');
+
       await axios.post('/.netlify/functions/slackSubmit', {
         params: {
           email,
+          recaptchaToken,
         },
       });
 
-      // TODO: surface success message
-      return setMessage(
-        'Success! Check your email for an invite to our Slack channel.'
-      );
+      return setMessage({
+        error: false,
+        body: 'Success! Check your email for an invite to our Slack channel.',
+      });
     } catch (e) {
       if (
+        e != null &&
         e.response != null &&
         e.response.data != null &&
         e.response.data.error != null
       ) {
         switch (e.response.data.error) {
+          case 'invalid-recaptcha':
+            return setMessage({
+              error: true,
+              body:
+                'There was an issue with verifying your request. Please refresh the page and try again.',
+            });
+          case 'recaptcha-failed':
+            return setMessage({
+              error: true,
+              body:
+                'Recaptcha failed. If you are using a VPN, please disable it and try again.',
+            });
           case 'already_in_team_invited_user':
-            return setMessage('You have already been invited to this team.');
+            return setMessage({
+              error: true,
+              message: 'You have already been invited to this team.',
+            });
           case 'invalid_email':
-            return setMessage('Invalid email address.');
+            return setMessage({
+              error: true,
+              message: 'Please enter a valid email address.',
+            });
           default:
             return setMessage(
               'An unexpected error occurred. Please refresh the page and try again.'
             );
         }
       } else {
-        return setMessage(
-          'An unexpected error occurred. Please refresh the page and try again.'
-        );
+        return setMessage({
+          error: true,
+          message:
+            'An unexpected error occurred. Please refresh the page and try again.',
+        });
       }
     } finally {
       setLoading(false);
@@ -61,6 +97,7 @@ const InviteForm = () => {
 
   return (
     <>
+      <RecaptchaText />
       <Styled.Form onSubmit={handleSubmit}>
         <Styled.Input
           placeholder="you@email.com"
@@ -69,11 +106,27 @@ const InviteForm = () => {
           onChange={handleEmailChange}
           value={email}
         />
-        <Button type="submit" disabled={!isValidEmail(email) || loading}>
+        <Button type="submit" disabled={message.error || loading}>
           Get Invite
         </Button>
       </Styled.Form>
-      {message.length > 0 && <Styled.Message>{message}</Styled.Message>}
+      {message.body != null && (
+        <Text fontSize={2} fontWeight={600} mt={3} color="Blues.100">
+          {message.body}
+        </Text>
+      )}
+
+      <Text fontSize={1} mt={3} display="block" color="Grays.100">
+        Or if you&apos;re already a member{' '}
+        <a
+          href="https://newhavenio.slack.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          sign in
+        </a>
+        .
+      </Text>
     </>
   );
 };
@@ -81,3 +134,17 @@ const InviteForm = () => {
 InviteForm.propTypes = {};
 
 export default InviteForm;
+
+/**
+ * Because we hide the Recaptcha banner via CSS, we are legally required to
+ * show this text.
+ *
+ * https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
+ */
+const RecaptchaText = () => (
+  <Text fontSize={1} mb={2} display="block" color="Grays.60">
+    This site is protected by reCAPTCHA and the Google&nbsp;
+    <a href="https://policies.google.com/privacy">Privacy Policy</a> and&nbsp;
+    <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+  </Text>
+);

--- a/src/global.css.js
+++ b/src/global.css.js
@@ -121,4 +121,7 @@ export default createGlobalStyle`
     line-height: 1.5;
     margin-bottom: 2rem;
   }
+
+  /* Visually hide recaptcha badge */
+  .grecaptcha-badge { visibility: hidden; }
 `;

--- a/src/lambda/slackSubmit.js
+++ b/src/lambda/slackSubmit.js
@@ -3,41 +3,81 @@ import axios from 'axios';
 
 dotenv.config();
 
+const RECAPTCHA_ENDPOINT = 'https://www.google.com/recaptcha/api/siteverify';
+const SLACK_TOKEN = process.env.SLACK_TOKEN;
+const SLACK_INVITE_ENDPOINT = 'https://slack.com/api/users.admin.invite';
+
+// TODO: Move this to Netlify env vars @a-trost
+// This is NOT ok! This is a secret!
+// Currently we are using a test key for Netlify. Once we swap for a key on
+// the newhaven.io domain, this MUST be stored in Netlify secret management.
+const RECAPTCHA_SECRET_KEY = '6LfTTMQUAAAAAJirVZO6XgpNCj-94HfJ_rclZu3G';
+
+/**
+ * Invites the given email to our Slack channel.
+ *
+ * @name Slack Submit
+ * @path {POST} /.netlify/functions/slackSubmit
+ * @body {String} email
+ * @body {String} recaptchaToken the recaptcha user response token
+ * @response {String} error failure reason
+ */
 export async function handler(event, _context, callback) {
   const payload = JSON.parse(event.body);
   const email = encodeURIComponent(payload.params.email.trim());
-  const SLACK_TOKEN = process.env.SLACK_TOKEN;
-  const SLACK_INVITE_ENDPOINT = 'https://slack.com/api/users.admin.invite';
   const toSlack = `email=${email}&token=${SLACK_TOKEN}&set_active=true`;
 
-  await axios
-    .get(`${SLACK_INVITE_ENDPOINT}?${toSlack}`)
-    .then(response => {
-      if (response.data.error != null) {
-        callback(null, {
-          statusCode: 400,
-          body: JSON.stringify({
-            email,
-            error: response.data.error,
-          }),
-        });
-      }
+  const {
+    data: { success, score },
+  } = await axios.post(RECAPTCHA_ENDPOINT, {
+    secret: RECAPTCHA_SECRET_KEY,
+    response: payload.params.recaptchaToken,
+  });
 
-      callback(null, {
-        statusCode: 200,
-        body: JSON.stringify({
-          email,
-          data: response.data,
-        }),
-      });
-    })
-    .catch(error => {
-      callback(null, {
-        statusCode: 500,
-        body: JSON.stringify({
-          email,
-          error: error.message,
-        }),
-      });
+  if (!success) {
+    // Recaptcha itself was invalid -- might mean key was misconfigured
+    return callback(null, {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: 'invalid-recaptcha',
+      }),
     });
+  }
+
+  if (score < 0.5) {
+    // Recaptcha failed
+    return callback(null, {
+      statusCode: 429,
+      body: JSON.stringify({
+        error: 'recaptcha-failed',
+      }),
+    });
+  }
+
+  try {
+    const { data } = await axios.get(`${SLACK_INVITE_ENDPOINT}?${toSlack}`);
+
+    if (data.error != null) {
+      // Slack invite failed -- can mean malformed email or user already invited
+      return callback(null, {
+        statusCode: 422,
+        body: JSON.stringify({
+          error: data.error,
+        }),
+      });
+    }
+
+    // Invite succeeded
+    return callback(null, {
+      statusCode: 200,
+    });
+  } catch (error) {
+    // Mystery error
+    return callback(null, {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: error.message,
+      }),
+    });
+  }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -51,17 +51,6 @@ const Index = () => (
         Lorem ipsum dolor sit amet consectetur, adipisicing elit.
       </Text>
       <InviteForm />
-      <Text fontSize={1} mt={3} display="block" color="Grays.100">
-        Or if you&apos;re already a member{' '}
-        <a
-          href="https://newhavenio.slack.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          sign in
-        </a>
-        .
-      </Text>
     </Box>
     <Box
       minHeight="300px"

--- a/src/store/provider.js
+++ b/src/store/provider.js
@@ -1,6 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3';
+
 import { Provider } from './createContext';
+
+// TODO: Move this to Netlify env vars @a-trost
+// This is ok, since the site key is not a sensitive secret, but managing on
+// the cloud is easier.
+const RECAPTCHA_SITE_KEY = '6LfTTMQUAAAAALXesYrKf-QxkzL19sGuBlfxPr4l';
 
 // The provider, which holds the page-wide store and its actions.
 // Feel free to abstract actions and state away from this file.
@@ -12,7 +19,13 @@ class AppProvider extends Component {
   };
 
   render() {
-    return <Provider value={this.state}>{this.props.children}</Provider>;
+    return (
+      <Provider value={this.state}>
+        <GoogleReCaptchaProvider reCaptchaKey={RECAPTCHA_SITE_KEY}>
+          {this.props.children}
+        </GoogleReCaptchaProvider>
+      </Provider>
+    );
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9984,6 +9984,11 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
+
 hoist-non-react-statics@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#101685d3aff3b23ea213163f6e8e12f4f111e19f"
@@ -15094,6 +15099,13 @@ react-focus-lock@^2.1.0:
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.2"
     use-sidecar "^1.0.1"
+
+react-google-recaptcha-v3@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.5.0.tgz#9144afd2701622c0b7777efe68696d014b261ab7"
+  integrity sha512-74GuTpHHkLV4O7Ye06OW/nWgmk9mBCo1DcF6hTFxn0x+EIFRaGxwHMAsIfWxYxBGGeS8X0DFlLucUv94qbdR2g==
+  dependencies:
+    hoist-non-react-statics "^2.5.5"
 
 react-headroom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Closes #30.

Currently using the recommended .5 as the recaptcha threshold, this can
be tweaked.

Also currently using keys owned by myself that work for the fervent
kepler domain, WITH SECRET KEYS IN THE CODE ITSELF. These should be
switched to target the NHIO domain and live in Netlify secrets in the
future.