### PR TITLE
fix(Nav): Remove partiallyActive from index link

### DIFF
--- a/src/components/header/mobilenav/mobilenav.js
+++ b/src/components/header/mobilenav/mobilenav.js
@@ -20,12 +20,7 @@ const Menu = ({ onClick }) => (
     <NavContainer>
       <ul>
         <li>
-          <Link
-            partiallyActive
-            activeClassName="active"
-            to="/"
-            onClick={onClick}
-          >
+          <Link activeClassName="active" to="/" onClick={onClick}>
             Home
           </Link>
         </li>

--- a/src/components/header/nav/nav.js
+++ b/src/components/header/nav/nav.js
@@ -29,7 +29,7 @@ const Nav = () => (
         <Container>
           <ul>
             <motion.li {...entryAnimation(0)}>
-              <Link partiallyActive activeClassName="active" to="/">
+              <Link activeClassName="active" to="/">
                 Home
               </Link>
             </motion.li>


### PR DESCRIPTION
Doesn't function correctly since it matches everything. BAD GATSBY!

Should be fine if this is inconsistently highlighted since it looks less
weird that the index route isn't highlighted.