### PR TITLE
fix(Header): Fix flash on mount

### DIFF
--- a/src/components/header/header.css.js
+++ b/src/components/header/header.css.js
@@ -4,7 +4,6 @@ import breakpoints from 'constants/theme/breakpoints';
 
 export const Headroom = styled(reactHeadroom)`
   background: ${p => p.theme.colors.Gradients.Orange};
-  height: 140px;
 
   svg {
     width: 75px;


### PR DESCRIPTION
Took a while of hunting to track this down!

`140px` actually doesn't correspond to anything and the header instantly
resizes to fit content once it mounts. So on the first render frame it
will be 140px, pushing everything else down, and on the second frame it
becomes 110 (the actual content height), causing the rest of the page to
leap by 30px.