### PR TITLE
fix: fix mobile nav when device is in landscape orientation

### DIFF
--- a/src/components/header/mobilenav/mobilenav.css.js
+++ b/src/components/header/mobilenav/mobilenav.css.js
@@ -1,6 +1,8 @@
 import styled, { createGlobalStyle } from 'styled-components';
 import { motion } from 'framer-motion';
 
+import breakpoints from 'constants/theme/breakpoints';
+
 import { NavContainer as _NavContainer } from '../navcontainer.css';
 
 export const ModalStyle = createGlobalStyle`
@@ -28,6 +30,14 @@ export const NavContainer = styled(_NavContainer)`
   margin-bottom: 9rem;
   margin-left: 3rem;
 
+  @media screen and (max-height: ${breakpoints.sm}) {
+    margin-bottom: 3rem;
+  }
+
+  @media screen and (max-height: ${breakpoints.xs}) {
+    margin-bottom: 1rem;
+  }
+
   ul {
     flex-direction: column;
     justify-content: flex-end;
@@ -35,6 +45,10 @@ export const NavContainer = styled(_NavContainer)`
     li {
       font-size: 2.5rem;
       margin-bottom: 0.5rem;
+
+      @media screen and (max-height: ${breakpoints.xs}) {
+        font-size: 1.75rem;
+      }
     }
   }
 `;

--- a/src/components/shared/modal/modal.js
+++ b/src/components/shared/modal/modal.js
@@ -1,8 +1,18 @@
 import React, { useCallback, useEffect } from 'react';
+import { createGlobalStyle } from 'styled-components';
 import PropTypes from 'prop-types';
 import { Dialog } from '@reach/dialog';
 
 import '@reach/dialog/styles.css';
+
+// @reach/dialog imports react-remove-scroll-bar which incorrectly computes
+// screen width for very small screens, adding an extra margin-right when the
+// mobile nav is opened. This removes it.
+const FixReactRemoveScrollGlobalStyle = createGlobalStyle`
+  html body {
+    margin-right: 0 !important;
+  }
+`;
 
 const Modal = ({ open, hideModal, children, ...props }) => {
   const handleKeyDown = useCallback(
@@ -16,9 +26,12 @@ const Modal = ({ open, hideModal, children, ...props }) => {
   }, [handleKeyDown]);
 
   return (
-    <Dialog isOpen={open} {...props}>
-      {children}
-    </Dialog>
+    <>
+      {open && <FixReactRemoveScrollGlobalStyle />}
+      <Dialog isOpen={open} {...props}>
+        {children}
+      </Dialog>
+    </>
   );
 };
 

--- a/src/constants/theme/breakpoints.js
+++ b/src/constants/theme/breakpoints.js
@@ -1,10 +1,11 @@
 // theme.js
-const breakpoints = ['512px', '768px', '1024px', '1408px'];
+const breakpoints = ['375px', '512px', '768px', '1024px', '1408px'];
 
 // aliases
-breakpoints.sm = breakpoints[0];
-breakpoints.md = breakpoints[1];
-breakpoints.lg = breakpoints[2];
-breakpoints.xl = breakpoints[3];
+breakpoints.xs = breakpoints[0];
+breakpoints.sm = breakpoints[1];
+breakpoints.md = breakpoints[2];
+breakpoints.lg = breakpoints[3];
+breakpoints.xl = breakpoints[4];
 
 export default breakpoints;


### PR DESCRIPTION
- Adds height breakpoint so menu isn't cut off
- Fixes incorrect resizing on really small devices