### PR TITLE
refactor: make typewriter more SSR-friendly

### DIFF
--- a/src/components/shared/animatedtitle/animatedtitle.css.js
+++ b/src/components/shared/animatedtitle/animatedtitle.css.js
@@ -12,4 +12,18 @@ export const Title = styled(TitleText)`
         opacity: 0;
       }
     `};
+
+  > span:last-child {
+    display: block;
+  }
+
+  /*
+   * On mobile, we want the first line to break, to avoid jank from the
+   * typewriter effect.
+   */
+  @media screen and (max-width: ${p => p.theme.breakpoints.sm}) {
+    > span:first-child {
+      display: block;
+    }
+  }
 `;

--- a/src/components/shared/animatedtitle/animatedtitle.js
+++ b/src/components/shared/animatedtitle/animatedtitle.js
@@ -70,7 +70,7 @@ const AnimatedTitle = () => {
 
   return (
     <Styled.Title as="h2" size="large" active={hasStarted}>
-      Where {isSmall && <br />}
+      <span>Where</span>{' '}
       <Typed
         // This component leverages caching, so this forces a cache reset once we loop
         key={hasLooped ? 0 : 1}
@@ -88,8 +88,7 @@ const AnimatedTitle = () => {
       >
         {!hasLooped && <span>tech</span>}
       </Typed>
-      <br />
-      happens in New Haven
+      <span>happens in New Haven</span>
     </Styled.Title>
   );
 };


### PR DESCRIPTION
Implement linebreaks with media queries instead of resize listeners.
This removes linebreak jank when loading on small mobile devices.